### PR TITLE
Add guards for Storage URL usage

### DIFF
--- a/resources/views/components/cart-drawer.blade.php
+++ b/resources/views/components/cart-drawer.blade.php
@@ -1,4 +1,7 @@
-@php use Illuminate\Support\Facades\Storage; @endphp
+@php
+    use Illuminate\Support\Facades\Storage;
+    use Illuminate\Support\Facades\Log;
+@endphp
 <div x-data="{ drawerOpen: false }">
     <!-- Open Button -->
     <button @click="drawerOpen = true"
@@ -70,7 +73,17 @@
                                 @forelse($cart as $key => $item)
                                     <li class="flex py-6">
                                         <div class="size-24 shrink-0 overflow-hidden rounded-md border border-[#A6977C]/50">
-                                            <img src="{{ Storage::disk('public_assets')->url($item['image']) }}"
+                                            @php
+                                                $imgPath = $item['image'] ?? null;
+                                                if (! is_string($imgPath) || trim($imgPath) === '') {
+                                                    Log::warning('Missing cart item image', ['product_id' => $item['product_id'] ?? null]);
+                                                }
+
+                                                $imgUrl = is_string($imgPath) && trim($imgPath) !== ''
+                                                    ? Storage::disk('public_assets')->url($imgPath)
+                                                    : asset('images/no image.jpeg');
+                                            @endphp
+                                            <img src="{{ $imgUrl }}"
                                                  alt="{{ $item['product_name'] ?? $item['name'] ?? 'Unnamed Product' }}"
                                                  class="size-full object-cover">
                                         </div>

--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -8,8 +8,20 @@
         <div class="max-w-5xl mx-auto bg-white rounded-lg shadow-md p-6 sm:p-10 grid grid-cols-1 sm:grid-cols-2 gap-6">
             <!-- Left: Product Image -->
             <div>
-                @php use Illuminate\Support\Facades\Storage; @endphp
-                <img src="{{ Storage::disk('public_assets')->url($product->image) }}"
+                @php
+                    use Illuminate\Support\Facades\Storage;
+                    use Illuminate\Support\Facades\Log;
+
+                    $imgPath = $product->image ?? null;
+                    if (! is_string($imgPath) || trim($imgPath) === '') {
+                        Log::warning('Missing product image', ['product_id' => $product->id]);
+                    }
+
+                    $imgUrl = is_string($imgPath) && trim($imgPath) !== ''
+                        ? Storage::disk('public_assets')->url($imgPath)
+                        : asset('images/no image.jpeg');
+                @endphp
+                <img src="{{ $imgUrl }}"
                      alt="{{ $product->name }}"
                      class="w-full max-h-[450px] object-cover rounded-md bg-[#F3F2EF]">
             </div>


### PR DESCRIPTION
## Summary
- prevent invalid paths when showing product images
- handle missing images in cart drawer

## Testing
- `composer test` *(fails: composer not installed)*
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684cc83bac98832cb8bdf42813b044ee